### PR TITLE
Update Gumroad checkout redirect URL note to production domain

### DIFF
--- a/src/pages/Purchase.tsx
+++ b/src/pages/Purchase.tsx
@@ -23,7 +23,7 @@ import {
 // Gumroad product configuration
 const GUMROAD_PRODUCT_ID = "rebelkit";
 // Note: Set up redirect in Gumroad product settings: Product > Checkout > After purchase redirect URL
-// Set it to: https://kindai.io/purchase/redirect
+// Set it to: https://kindai-showcase-shop.lovable.app/purchase/redirect
 const GUMROAD_PRODUCT_URL = `https://matthewgas.gumroad.com/l/rebelkit?wanted=true`;
 
 const Purchase = () => {


### PR DESCRIPTION
### Motivation
- Ensure the Gumroad "After purchase redirect" instruction points to the production license-activation page so buyers land on the correct flow after paying.  
- Replace the outdated comment that referenced `https://kindai.io/purchase/redirect` with the production redirect URL `https://kindai-showcase-shop.lovable.app/purchase/redirect`.

### Description
- Update the comment in `src/pages/Purchase.tsx` to advise setting Gumroad's After purchase redirect URL to `https://kindai-showcase-shop.lovable.app/purchase/redirect`.  
- This is a comment-only change and does not modify runtime logic or application behavior.

### Testing
- No automated tests were run because this change only updates a source comment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_696217e1467c832a9941958db8d98810)