### PR TITLE
Add theme toggle, direct CTAs to purchase, and improve purchase/auth flows

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -79,10 +79,10 @@ const Hero = () => {
             <Button 
               size="lg" 
               className="text-lg px-8 py-6 gradient-rebel hover:opacity-90 transition-smooth shadow-glow group active:scale-95 touch-feedback" 
-              onClick={() => navigate("/toolkit")}
+              onClick={() => navigate("/purchase")}
             >
               <Sparkles className="mr-2 w-5 h-5" />
-              Access Rebel Toolkit
+              Get Rebel Toolkit
               <ArrowRight className="ml-2 group-hover:translate-x-1 transition-smooth" />
             </Button>
             <Button 

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,11 +1,12 @@
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Menu, X } from "lucide-react";
-import { useState } from "react";
+import { Menu, X, Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
 import logo from "@/assets/kindai-logo-with-bird.png";
 
 const SiteHeader = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const location = useLocation();
 
   const navLinks = [
@@ -15,6 +16,22 @@ const SiteHeader = () => {
   ];
 
   const isActive = (path: string) => location.pathname === path;
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initialTheme = storedTheme ?? (prefersDark ? "dark" : "light");
+    const shouldUseDark = initialTheme === "dark";
+    document.documentElement.classList.toggle("dark", shouldUseDark);
+    setIsDarkMode(shouldUseDark);
+  }, []);
+
+  const handleThemeToggle = () => {
+    const nextMode = !isDarkMode;
+    setIsDarkMode(nextMode);
+    document.documentElement.classList.toggle("dark", nextMode);
+    localStorage.setItem("theme", nextMode ? "dark" : "light");
+  };
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/80 backdrop-blur-md">
@@ -51,7 +68,16 @@ const SiteHeader = () => {
           </nav>
 
           {/* CTA Buttons */}
-          <div className="hidden md:flex items-center gap-3">
+          <div className="hidden md:flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={handleThemeToggle}
+              aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+            >
+              {isDarkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            </Button>
             <Link to="/auth">
               <Button variant="ghost" size="sm">
                 Sign In
@@ -97,6 +123,18 @@ const SiteHeader = () => {
                 </Link>
               ))}
               <div className="flex flex-col gap-2 pt-4 border-t border-border/40">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    handleThemeToggle();
+                    setMobileMenuOpen(false);
+                  }}
+                >
+                  {isDarkMode ? "Light Mode" : "Dark Mode"}
+                </Button>
                 <Link to="/auth" onClick={() => setMobileMenuOpen(false)}>
                   <Button variant="outline" size="sm" className="w-full">
                     Sign In

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-// Enable dark mode globally
-document.documentElement.classList.add('dark');
+const storedTheme = localStorage.getItem("theme");
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+const initialTheme = storedTheme ?? (prefersDark ? "dark" : "light");
+
+document.documentElement.classList.toggle("dark", initialTheme === "dark");
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Mail, Lock, ArrowRight, Sparkles } from "lucide-react";
@@ -101,9 +102,14 @@ const Auth = () => {
         </div>
 
         <form onSubmit={handleAuth} className="space-y-4">
-          <div className="relative">
+          <div className="space-y-2">
+            <Label htmlFor="auth-email" className="text-sm font-medium">
+              Email
+            </Label>
+            <div className="relative">
             <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
             <Input
+              id="auth-email"
               type="email"
               placeholder="Email"
               value={email}
@@ -111,11 +117,17 @@ const Auth = () => {
               className="pl-10"
               required
             />
+            </div>
           </div>
 
-          <div className="relative">
+          <div className="space-y-2">
+            <Label htmlFor="auth-password" className="text-sm font-medium">
+              Password
+            </Label>
+            <div className="relative">
             <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
             <Input
+              id="auth-password"
               type="password"
               placeholder="Password"
               value={password}
@@ -124,6 +136,7 @@ const Auth = () => {
               required
               minLength={6}
             />
+            </div>
           </div>
 
           <Button

--- a/src/pages/HowItWorks.tsx
+++ b/src/pages/HowItWorks.tsx
@@ -398,7 +398,7 @@ const HowItWorksPage = () => {
               <Button
                 size="lg"
                 className="text-lg px-8 py-6 gradient-rebel hover:opacity-90 transition-smooth shadow-glow group"
-                onClick={() => navigate("/toolkit")}
+                onClick={() => navigate("/purchase")}
               >
                 <Sparkles className="mr-2 w-5 h-5" />
                 Try Rebel Toolkit Now

--- a/src/pages/Purchase.tsx
+++ b/src/pages/Purchase.tsx
@@ -34,6 +34,7 @@ const Purchase = () => {
   const { hasPurchased, isLoading: purchaseLoading, refetch } = usePurchaseStatus(user);
   const navigate = useNavigate();
   const { toast } = useToast();
+  const isSignedIn = Boolean(user);
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -118,22 +119,6 @@ const Purchase = () => {
     );
   }
 
-  if (!user) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background p-4">
-        <div className="text-center space-y-6 max-w-md">
-          <h1 className="text-2xl font-bold">Sign in to continue</h1>
-          <p className="text-muted-foreground">
-            You need to be signed in to purchase or verify your license.
-          </p>
-          <Button onClick={() => navigate("/auth")} size="lg">
-            Sign In
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
   const features = [
     { icon: Bot, label: "3 AI Agents", desc: "Brand Voice, Offer, Business Test" },
     { icon: BookOpen, label: "Complete Guides", desc: "Step-by-step rebel playbooks" },
@@ -150,7 +135,13 @@ const Purchase = () => {
             <ArrowLeft className="w-4 h-4" />
             Back
           </Button>
-          <span className="text-sm text-muted-foreground">{user.email}</span>
+          {isSignedIn ? (
+            <span className="text-sm text-muted-foreground">{user?.email}</span>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => navigate("/auth")}>
+              Sign In
+            </Button>
+          )}
         </div>
       </header>
 
@@ -164,20 +155,34 @@ const Purchase = () => {
               </div>
               <div>
                 <h2 className="text-lg font-semibold">Already purchased?</h2>
-                <p className="text-sm text-muted-foreground">Enter your license key to unlock access</p>
+                <p className="text-sm text-muted-foreground">
+                  {isSignedIn ? "Enter your license key to unlock access" : "Sign in to verify your license key."}
+                </p>
               </div>
             </div>
-            <form onSubmit={handleVerifyLicense} className="flex gap-2 flex-1">
-              <Input
-                type="text"
-                placeholder="Enter license key..."
-                value={licenseKey}
-                onChange={(e) => setLicenseKey(e.target.value)}
-                className="font-mono flex-1"
-              />
-              <Button type="submit" disabled={isVerifying} className="shrink-0">
-                {isVerifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Unlock"}
-              </Button>
+            <form onSubmit={handleVerifyLicense} className="flex flex-col gap-2 flex-1">
+              <Label htmlFor="license-key" className="text-sm font-medium">
+                License key
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="license-key"
+                  type="text"
+                  placeholder="Enter license key..."
+                  value={licenseKey}
+                  onChange={(e) => setLicenseKey(e.target.value)}
+                  className="font-mono flex-1"
+                  disabled={!isSignedIn}
+                />
+                <Button type="submit" disabled={isVerifying || !isSignedIn} className="shrink-0">
+                  {isVerifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Unlock"}
+                </Button>
+              </div>
+              {!isSignedIn && (
+                <Button variant="outline" size="sm" onClick={() => navigate("/auth")}>
+                  Sign in to verify
+                </Button>
+              )}
             </form>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Provide a persistent light/dark mode that respects stored preference and system setting, improve conversion by directing primary CTAs into the purchase flow, and make the purchase/auth forms more accessible and usable for signed-out visitors.

### Description
- Initialize theme in `src/main.tsx` by reading `localStorage` and `prefers-color-scheme`, and toggle the `dark` class accordingly.
- Add a theme toggle button and persisted toggle logic to `src/components/SiteHeader.tsx` with a mobile option to switch themes.
- Update primary CTAs in `src/components/Hero.tsx` and `src/pages/HowItWorks.tsx` to navigate to the purchase flow (`/purchase`) and adjust copy to encourage purchase.
- Improve `src/pages/Purchase.tsx` to support signed-out visitors by showing a sign-in CTA, add a labeled license input with disabled/unlock behavior when not signed in, and prevent automatic blocking of the entire page for anonymous users.
- Add explicit `Label` elements to `src/pages/Auth.tsx` inputs to improve accessibility and input targeting.

### Testing
- Ran `npm run lint`, which failed due to pre-existing lint issues in the repo and reported `32 problems (24 errors, 8 warnings)` related to existing TypeScript/ESLint rules; no new lint rule failures were introduced by these changes.
- Started the dev server with `npm run dev` and Vite booted successfully and served the app locally.
- Executed a Playwright script to load the app and capture a screenshot of the homepage, which completed successfully and produced `artifacts/kindai-home.png`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966de587998832a8944b2ce10f1a02d)