### PR TITLE
Persist selected pricing tier and save tier/variant/price to purchase records

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -79,10 +79,10 @@ const Hero = () => {
             <Button 
               size="lg" 
               className="text-lg px-8 py-6 gradient-rebel hover:opacity-90 transition-smooth shadow-glow group active:scale-95 touch-feedback" 
-              onClick={() => navigate("/toolkit")}
+              onClick={() => navigate("/purchase")}
             >
               <Sparkles className="mr-2 w-5 h-5" />
-              Access Rebel Toolkit
+              Get Rebel Toolkit
               <ArrowRight className="ml-2 group-hover:translate-x-1 transition-smooth" />
             </Button>
             <Button 

--- a/src/components/SiteHeader.tsx
+++ b/src/components/SiteHeader.tsx
@@ -1,11 +1,12 @@
 import { Link, useLocation } from "react-router-dom";
 import { Button } from "@/components/ui/button";
-import { Menu, X } from "lucide-react";
-import { useState } from "react";
+import { Menu, X, Moon, Sun } from "lucide-react";
+import { useEffect, useState } from "react";
 import logo from "@/assets/kindai-logo-with-bird.png";
 
 const SiteHeader = () => {
   const [mobileMenuOpen, setMobileMenuOpen] = useState(false);
+  const [isDarkMode, setIsDarkMode] = useState(false);
   const location = useLocation();
 
   const navLinks = [
@@ -15,6 +16,22 @@ const SiteHeader = () => {
   ];
 
   const isActive = (path: string) => location.pathname === path;
+
+  useEffect(() => {
+    const storedTheme = localStorage.getItem("theme");
+    const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+    const initialTheme = storedTheme ?? (prefersDark ? "dark" : "light");
+    const shouldUseDark = initialTheme === "dark";
+    document.documentElement.classList.toggle("dark", shouldUseDark);
+    setIsDarkMode(shouldUseDark);
+  }, []);
+
+  const handleThemeToggle = () => {
+    const nextMode = !isDarkMode;
+    setIsDarkMode(nextMode);
+    document.documentElement.classList.toggle("dark", nextMode);
+    localStorage.setItem("theme", nextMode ? "dark" : "light");
+  };
 
   return (
     <header className="sticky top-0 z-50 w-full border-b border-border/40 bg-background/80 backdrop-blur-md">
@@ -51,7 +68,16 @@ const SiteHeader = () => {
           </nav>
 
           {/* CTA Buttons */}
-          <div className="hidden md:flex items-center gap-3">
+          <div className="hidden md:flex items-center gap-2">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={handleThemeToggle}
+              aria-label={isDarkMode ? "Switch to light mode" : "Switch to dark mode"}
+            >
+              {isDarkMode ? <Sun className="h-4 w-4" /> : <Moon className="h-4 w-4" />}
+            </Button>
             <Link to="/auth">
               <Button variant="ghost" size="sm">
                 Sign In
@@ -97,6 +123,18 @@ const SiteHeader = () => {
                 </Link>
               ))}
               <div className="flex flex-col gap-2 pt-4 border-t border-border/40">
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => {
+                    handleThemeToggle();
+                    setMobileMenuOpen(false);
+                  }}
+                >
+                  {isDarkMode ? "Light Mode" : "Dark Mode"}
+                </Button>
                 <Link to="/auth" onClick={() => setMobileMenuOpen(false)}>
                   <Button variant="outline" size="sm" className="w-full">
                     Sign In

--- a/src/integrations/supabase/types.ts
+++ b/src/integrations/supabase/types.ts
@@ -287,36 +287,45 @@ export type Database = {
         Row: {
           created_at: string
           email: string
+          gumroad_variant: string | null
           gumroad_sale_id: string | null
           id: string
           is_verified: boolean
           license_key: string | null
+          price_cents: number | null
           product_id: string
           purchase_date: string | null
+          tier: string | null
           updated_at: string
           user_id: string | null
         }
         Insert: {
           created_at?: string
           email: string
+          gumroad_variant?: string | null
           gumroad_sale_id?: string | null
           id?: string
           is_verified?: boolean
           license_key?: string | null
+          price_cents?: number | null
           product_id: string
           purchase_date?: string | null
+          tier?: string | null
           updated_at?: string
           user_id?: string | null
         }
         Update: {
           created_at?: string
           email?: string
+          gumroad_variant?: string | null
           gumroad_sale_id?: string | null
           id?: string
           is_verified?: boolean
           license_key?: string | null
+          price_cents?: number | null
           product_id?: string
           purchase_date?: string | null
+          tier?: string | null
           updated_at?: string
           user_id?: string | null
         }

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -2,7 +2,10 @@ import { createRoot } from "react-dom/client";
 import App from "./App.tsx";
 import "./index.css";
 
-// Enable dark mode globally
-document.documentElement.classList.add('dark');
+const storedTheme = localStorage.getItem("theme");
+const prefersDark = window.matchMedia("(prefers-color-scheme: dark)").matches;
+const initialTheme = storedTheme ?? (prefersDark ? "dark" : "light");
+
+document.documentElement.classList.toggle("dark", initialTheme === "dark");
 
 createRoot(document.getElementById("root")!).render(<App />);

--- a/src/pages/Auth.tsx
+++ b/src/pages/Auth.tsx
@@ -3,6 +3,7 @@ import { useNavigate } from "react-router-dom";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Card } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
 import { supabase } from "@/integrations/supabase/client";
 import { toast } from "sonner";
 import { Mail, Lock, ArrowRight, Sparkles } from "lucide-react";
@@ -101,9 +102,14 @@ const Auth = () => {
         </div>
 
         <form onSubmit={handleAuth} className="space-y-4">
-          <div className="relative">
+          <div className="space-y-2">
+            <Label htmlFor="auth-email" className="text-sm font-medium">
+              Email
+            </Label>
+            <div className="relative">
             <Mail className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
             <Input
+              id="auth-email"
               type="email"
               placeholder="Email"
               value={email}
@@ -111,11 +117,17 @@ const Auth = () => {
               className="pl-10"
               required
             />
+            </div>
           </div>
 
-          <div className="relative">
+          <div className="space-y-2">
+            <Label htmlFor="auth-password" className="text-sm font-medium">
+              Password
+            </Label>
+            <div className="relative">
             <Lock className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-muted-foreground" />
             <Input
+              id="auth-password"
               type="password"
               placeholder="Password"
               value={password}
@@ -124,6 +136,7 @@ const Auth = () => {
               required
               minLength={6}
             />
+            </div>
           </div>
 
           <Button

--- a/src/pages/HowItWorks.tsx
+++ b/src/pages/HowItWorks.tsx
@@ -398,7 +398,7 @@ const HowItWorksPage = () => {
               <Button
                 size="lg"
                 className="text-lg px-8 py-6 gradient-rebel hover:opacity-90 transition-smooth shadow-glow group"
-                onClick={() => navigate("/toolkit")}
+                onClick={() => navigate("/purchase")}
               >
                 <Sparkles className="mr-2 w-5 h-5" />
                 Try Rebel Toolkit Now

--- a/src/pages/Purchase.tsx
+++ b/src/pages/Purchase.tsx
@@ -34,6 +34,7 @@ const Purchase = () => {
   const { hasPurchased, isLoading: purchaseLoading, refetch } = usePurchaseStatus(user);
   const navigate = useNavigate();
   const { toast } = useToast();
+  const isSignedIn = Boolean(user);
 
   useEffect(() => {
     const checkAuth = async () => {
@@ -73,10 +74,12 @@ const Purchase = () => {
     setIsVerifying(true);
 
     try {
+      const selectedTier = sessionStorage.getItem("selected_tier") || undefined;
       const { data, error } = await supabase.functions.invoke("gumroad-verify-license", {
         body: {
           license_key: licenseKey.trim(),
           product_id: GUMROAD_PRODUCT_ID,
+          tier: selectedTier,
         },
       });
 
@@ -89,6 +92,7 @@ const Purchase = () => {
           title: "License verified!",
           description: "Welcome to the Rebel Toolkit!",
         });
+        sessionStorage.removeItem("selected_tier");
         await refetch();
         navigate("/purchase/success");
       } else {
@@ -118,28 +122,41 @@ const Purchase = () => {
     );
   }
 
-  if (!user) {
-    return (
-      <div className="min-h-screen flex items-center justify-center bg-background p-4">
-        <div className="text-center space-y-6 max-w-md">
-          <h1 className="text-2xl font-bold">Sign in to continue</h1>
-          <p className="text-muted-foreground">
-            You need to be signed in to purchase or verify your license.
-          </p>
-          <Button onClick={() => navigate("/auth")} size="lg">
-            Sign In
-          </Button>
-        </div>
-      </div>
-    );
-  }
-
   const features = [
     { icon: Bot, label: "3 AI Agents", desc: "Brand Voice, Offer, Business Test" },
     { icon: BookOpen, label: "Complete Guides", desc: "Step-by-step rebel playbooks" },
     { icon: FileText, label: "Templates", desc: "Ready-to-use frameworks" },
     { icon: Zap, label: "Lifetime Access", desc: "All future updates included" },
   ];
+
+  const tiers = [
+    {
+      name: "Starter",
+      price: "$47",
+      cadence: "one-time",
+      highlight: "Best for solo rebels",
+      features: ["Full 3-Agent Toolkit", "Core guides + templates", "Lifetime updates"],
+      badge: "Most Popular",
+    },
+    {
+      name: "Growth",
+      price: "$97",
+      cadence: "one-time",
+      highlight: "For scaling your first offer",
+      features: ["Everything in Starter", "Advanced prompt packs", "Priority support"],
+    },
+    {
+      name: "Agency",
+      price: "$197",
+      cadence: "one-time",
+      highlight: "For teams + client work",
+      features: ["Everything in Growth", "Client-ready checklists", "Implementation playbooks"],
+    },
+  ];
+
+  const handleTierSelect = (tierName: string) => {
+    sessionStorage.setItem("selected_tier", tierName);
+  };
 
   return (
     <div className="min-h-screen bg-background">
@@ -150,7 +167,13 @@ const Purchase = () => {
             <ArrowLeft className="w-4 h-4" />
             Back
           </Button>
-          <span className="text-sm text-muted-foreground">{user.email}</span>
+          {isSignedIn ? (
+            <span className="text-sm text-muted-foreground">{user?.email}</span>
+          ) : (
+            <Button variant="ghost" size="sm" onClick={() => navigate("/auth")}>
+              Sign In
+            </Button>
+          )}
         </div>
       </header>
 
@@ -164,20 +187,34 @@ const Purchase = () => {
               </div>
               <div>
                 <h2 className="text-lg font-semibold">Already purchased?</h2>
-                <p className="text-sm text-muted-foreground">Enter your license key to unlock access</p>
+                <p className="text-sm text-muted-foreground">
+                  {isSignedIn ? "Enter your license key to unlock access" : "Sign in to verify your license key."}
+                </p>
               </div>
             </div>
-            <form onSubmit={handleVerifyLicense} className="flex gap-2 flex-1">
-              <Input
-                type="text"
-                placeholder="Enter license key..."
-                value={licenseKey}
-                onChange={(e) => setLicenseKey(e.target.value)}
-                className="font-mono flex-1"
-              />
-              <Button type="submit" disabled={isVerifying} className="shrink-0">
-                {isVerifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Unlock"}
-              </Button>
+            <form onSubmit={handleVerifyLicense} className="flex flex-col gap-2 flex-1">
+              <Label htmlFor="license-key" className="text-sm font-medium">
+                License key
+              </Label>
+              <div className="flex gap-2">
+                <Input
+                  id="license-key"
+                  type="text"
+                  placeholder="Enter license key..."
+                  value={licenseKey}
+                  onChange={(e) => setLicenseKey(e.target.value)}
+                  className="font-mono flex-1"
+                  disabled={!isSignedIn}
+                />
+                <Button type="submit" disabled={isVerifying || !isSignedIn} className="shrink-0">
+                  {isVerifying ? <Loader2 className="w-4 h-4 animate-spin" /> : "Unlock"}
+                </Button>
+              </div>
+              {!isSignedIn && (
+                <Button variant="outline" size="sm" onClick={() => navigate("/auth")}>
+                  Sign in to verify
+                </Button>
+              )}
             </form>
           </div>
         </div>
@@ -220,20 +257,57 @@ const Purchase = () => {
               ))}
             </div>
 
-            <div className="p-6 rounded-xl border border-primary/20 bg-primary/5 space-y-4">
-              <div className="flex items-baseline gap-2">
-                <span className="text-4xl font-bold">$47</span>
-                <span className="text-muted-foreground line-through">$97</span>
-                <span className="text-sm text-primary font-medium">Launch Price</span>
+            <div className="space-y-4">
+              <h2 className="text-2xl font-semibold">Choose your access tier</h2>
+              <div className="grid gap-4">
+                {tiers.map((tier) => (
+                  <div
+                    key={tier.name}
+                    className={`rounded-xl border p-5 space-y-4 ${
+                      tier.badge ? "border-primary/40 bg-primary/5" : "border-border bg-card"
+                    }`}
+                  >
+                    <div className="flex items-start justify-between gap-3">
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <h3 className="text-lg font-semibold">{tier.name}</h3>
+                          {tier.badge && (
+                            <span className="text-xs font-semibold uppercase tracking-wide text-primary bg-primary/10 px-2 py-1 rounded-full">
+                              {tier.badge}
+                            </span>
+                          )}
+                        </div>
+                        <p className="text-sm text-muted-foreground">{tier.highlight}</p>
+                      </div>
+                      <div className="text-right">
+                        <p className="text-3xl font-bold">{tier.price}</p>
+                        <p className="text-xs text-muted-foreground">{tier.cadence}</p>
+                      </div>
+                    </div>
+
+                    <ul className="text-sm text-muted-foreground space-y-1">
+                      {tier.features.map((feature) => (
+                        <li key={feature} className="flex items-start gap-2">
+                          <Check className="w-4 h-4 text-primary mt-0.5 shrink-0" />
+                          <span>{feature}</span>
+                        </li>
+                      ))}
+                    </ul>
+
+                    <Button
+                      size="lg"
+                      className="w-full gap-2"
+                      onClick={() => {
+                        handleTierSelect(tier.name);
+                        window.open(GUMROAD_PRODUCT_URL, "_blank");
+                      }}
+                    >
+                      Choose {tier.name}
+                      <ExternalLink className="w-4 h-4" />
+                    </Button>
+                  </div>
+                ))}
               </div>
-              <Button 
-                size="lg" 
-                className="w-full gap-2"
-                onClick={() => window.open(GUMROAD_PRODUCT_URL, "_blank")}
-              >
-                Buy Now on Gumroad
-                <ExternalLink className="w-4 h-4" />
-              </Button>
               <p className="text-xs text-center text-muted-foreground">
                 Secure payment via Gumroad. Instant access.
               </p>

--- a/src/pages/PurchaseRedirect.tsx
+++ b/src/pages/PurchaseRedirect.tsx
@@ -39,16 +39,19 @@ const PurchaseRedirect = () => {
 
       // Verify the license
       try {
+        const selectedTier = sessionStorage.getItem("selected_tier") || undefined;
         const { data, error } = await supabase.functions.invoke("gumroad-verify-license", {
           body: {
             license_key: licenseKey,
             product_id: GUMROAD_PRODUCT_ID,
+            tier: selectedTier,
           },
         });
 
         if (error) throw error;
 
         if (data.success) {
+          sessionStorage.removeItem("selected_tier");
           setStatus("success");
           setTimeout(() => navigate("/purchase/success"), 1500);
         } else {

--- a/supabase/functions/gumroad-verify-license/index.ts
+++ b/supabase/functions/gumroad-verify-license/index.ts
@@ -48,7 +48,7 @@ Deno.serve(async (req) => {
     }
 
     // Get license key from request body
-    const { license_key, product_id } = await req.json();
+    const { license_key, product_id, tier } = await req.json();
 
     if (!license_key || !product_id) {
       return new Response(
@@ -84,6 +84,9 @@ Deno.serve(async (req) => {
 
     // License is valid - store purchase record
     const purchase = gumroadData.purchase;
+    const purchaseVariant = purchase?.variant || purchase?.variants || null;
+    const purchaseTier = tier || deriveTierFromVariant(purchaseVariant);
+    const priceCents = Number.isFinite(Number(purchase?.price)) ? Number(purchase.price) : null;
     const serviceRoleKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
     const adminClient = createClient(supabaseUrl, serviceRoleKey);
 
@@ -101,6 +104,9 @@ Deno.serve(async (req) => {
         .update({ 
           user_id: user.id, 
           is_verified: true,
+          tier: purchaseTier,
+          gumroad_variant: purchaseVariant,
+          price_cents: priceCents,
           updated_at: new Date().toISOString()
         })
         .eq("gumroad_sale_id", purchase.sale_id);
@@ -116,6 +122,9 @@ Deno.serve(async (req) => {
           purchase_date: purchase.created_at || new Date().toISOString(),
           is_verified: true,
           gumroad_sale_id: purchase.sale_id,
+          tier: purchaseTier,
+          gumroad_variant: purchaseVariant,
+          price_cents: priceCents,
         });
 
       if (insertError) {
@@ -210,7 +219,8 @@ Deno.serve(async (req) => {
         success: true, 
         message: "License verified successfully",
         product_name: purchase.product_name,
-        email: purchase.email
+        email: purchase.email,
+        tier: purchaseTier
       }),
       { status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" } }
     );
@@ -223,3 +233,12 @@ Deno.serve(async (req) => {
     );
   }
 });
+
+const deriveTierFromVariant = (variant: string | null) => {
+  if (!variant) return null;
+  const normalized = variant.toLowerCase();
+  if (normalized.includes("starter")) return "Starter";
+  if (normalized.includes("growth")) return "Growth";
+  if (normalized.includes("agency")) return "Agency";
+  return null;
+};

--- a/supabase/functions/gumroad-webhook/index.ts
+++ b/supabase/functions/gumroad-webhook/index.ts
@@ -40,6 +40,9 @@ Deno.serve(async (req) => {
       product_name,
       seller_id 
     } = data;
+    const variantName = data.variants || data.variant || null;
+    const purchaseTier = deriveTierFromVariant(variantName);
+    const priceCents = Number.isFinite(Number(data.price)) ? Number(data.price) : null;
 
     if (!sale_id || !product_id || !email) {
       console.error("Missing required fields in webhook");
@@ -84,6 +87,9 @@ Deno.serve(async (req) => {
         purchase_date: new Date().toISOString(),
         is_verified: true,
         gumroad_sale_id: sale_id,
+        tier: purchaseTier,
+        gumroad_variant: variantName,
+        price_cents: priceCents,
       });
 
     if (insertError) {
@@ -109,3 +115,12 @@ Deno.serve(async (req) => {
     );
   }
 });
+
+const deriveTierFromVariant = (variant: string | null) => {
+  if (!variant) return null;
+  const normalized = variant.toLowerCase();
+  if (normalized.includes("starter")) return "Starter";
+  if (normalized.includes("growth")) return "Growth";
+  if (normalized.includes("agency")) return "Agency";
+  return null;
+};

--- a/supabase/migrations/20260201000000_add_purchase_tiers.sql
+++ b/supabase/migrations/20260201000000_add_purchase_tiers.sql
@@ -1,0 +1,4 @@
+ALTER TABLE public.user_purchases
+ADD COLUMN IF NOT EXISTS tier TEXT,
+ADD COLUMN IF NOT EXISTS gumroad_variant TEXT,
+ADD COLUMN IF NOT EXISTS price_cents INTEGER;


### PR DESCRIPTION
### Motivation
- Ensure the selected pricing tier from the new three-tier UI is captured and persisted so backend records reflect the buyer's chosen tier. 
- Record richer purchase metadata (tier, Gumroad variant, and price) from both the license verification flow and Gumroad webhooks to support entitlement checks and analytics. 
- Keep the front-end and generated Supabase types in sync with the new database columns so code is type-safe and queries can use the new fields.

### Description
- Frontend: added `handleTierSelect` in `src/pages/Purchase.tsx` to store the chosen tier in `sessionStorage`, pass `tier` to the `gumroad-verify-license` function call, and clear the stored tier on successful verification; `src/pages/PurchaseRedirect.tsx` also reads/passes `selected_tier` and clears it after success. 
- Backend: updated `supabase/functions/gumroad-verify-license/index.ts` to accept `tier`, derive a tier from Gumroad variant when needed via `deriveTierFromVariant`, capture `gumroad_variant` and `price_cents`, persist `tier/gumroad_variant/price_cents` to `user_purchases`, and return `tier` in the response. 
- Webhook: enhanced `supabase/functions/gumroad-webhook/index.ts` to derive and store `tier`, `gumroad_variant`, and `price_cents` when inserting purchases. 
- Schema & types: added a migration `supabase/migrations/20260201000000_add_purchase_tiers.sql` to add `tier`, `gumroad_variant`, and `price_cents` to `user_purchases`, and updated `src/integrations/supabase/types.ts` to include the new fields. 
- Misc: adjusted purchase CTAs to select tiers, and made small UX/accessibility improvements (`Label` on auth inputs, theme init and toggle in `src/main.tsx`/`SiteHeader.tsx`, CTA copy updates) as part of the broader rollout.

### Testing
- No automated tests were executed for this change; the modifications are schema and backend-function focused and require database migration and environment verification. 
- A database migration file was added (`supabase/migrations/20260201000000_add_purchase_tiers.sql`) and the generated types were updated to reflect the new columns. 
- Manual verification steps recommended: run the migration against a staging Supabase instance, exercise a Gumroad purchase or webhook to confirm `user_purchases` receives `tier`, `gumroad_variant`, and `price_cents`, and verify `gumroad-verify-license` accepts and persists the `tier` parameter.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6966de587998832a8944b2ce10f1a02d)